### PR TITLE
Add pytest coverage for sampler utilities and moves

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_dual_averaging.py
+++ b/tests/test_dual_averaging.py
@@ -1,0 +1,61 @@
+import jax.numpy as jnp
+
+from hemcee.dual_averaging import DAState, da_cond_update
+
+
+def test_da_cond_update_in_warmup_branch():
+    state = DAState(
+        step_size=jnp.array(0.5),
+        H_bar=jnp.array(0.0),
+        log_epsilon_bar=jnp.array(jnp.log(0.5)),
+    )
+
+    updated = da_cond_update(
+        iteration=0,
+        warmup_length=5,
+        accept_prob=0.2,
+        target_accept=0.8,
+        t0=10.0,
+        mu=0.05,
+        gamma=0.05,
+        kappa=0.75,
+        state=state,
+    )
+
+    it = 0
+    H_bar_new = ((1.0 - 1.0 / (it + 1 + 10.0)) * state.H_bar
+                 + (0.8 - 0.2) / (it + 1 + 10.0))
+    log_eps = 0.05 - (jnp.sqrt(it + 1.0) / 0.05) * H_bar_new
+    eta = (it + 1.0) ** (-0.75)
+    log_eps_bar_new = eta * log_eps + (1.0 - eta) * state.log_epsilon_bar
+    expected = DAState(jnp.exp(log_eps), H_bar_new, log_eps_bar_new)
+
+    assert jnp.allclose(updated.step_size, expected.step_size)
+    assert jnp.allclose(updated.H_bar, expected.H_bar)
+    assert jnp.allclose(updated.log_epsilon_bar, expected.log_epsilon_bar)
+
+
+def test_da_cond_update_after_warmup_branch():
+    state = DAState(
+        step_size=jnp.array(0.5),
+        H_bar=jnp.array(0.1),
+        log_epsilon_bar=jnp.array(jnp.log(0.3)),
+    )
+
+    updated = da_cond_update(
+        iteration=5,
+        warmup_length=5,
+        accept_prob=0.2,
+        target_accept=0.8,
+        t0=10.0,
+        mu=0.05,
+        gamma=0.05,
+        kappa=0.75,
+        state=state,
+    )
+
+    expected = DAState(jnp.exp(state.log_epsilon_bar), state.H_bar, state.log_epsilon_bar)
+
+    assert jnp.allclose(updated.step_size, expected.step_size)
+    assert jnp.allclose(updated.H_bar, expected.H_bar)
+    assert jnp.allclose(updated.log_epsilon_bar, expected.log_epsilon_bar)

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -1,0 +1,118 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+from hemcee.dual_averaging import DAState
+from hemcee.moves.vanilla.side import side_move
+from hemcee.moves.vanilla.stretch import stretch_move
+from hemcee.moves.vanilla.walk import walk_move
+from hemcee.moves.hamiltonian.hmc_side import hmc_side_move
+from hemcee.moves.hamiltonian.hmc_walk import hmc_walk_move
+
+
+def gaussian_log_prob(x):
+    return -0.5 * jnp.sum(x**2, axis=-1)
+
+
+def gaussian_potential(x):
+    return 0.5 * jnp.sum(x**2, axis=-1)
+
+
+def gaussian_potential_grad(x):
+    return x
+
+
+def _build_groups(n_chains_per_group: int = 4, dim: int = 3):
+    group1 = jnp.linspace(0.0, 1.0, num=n_chains_per_group * dim).reshape(
+        n_chains_per_group, dim
+    )
+    group2 = jnp.linspace(1.0, 2.0, num=n_chains_per_group * dim).reshape(
+        n_chains_per_group, dim
+    )
+    return group1, group2
+
+
+def run_vanilla_move_test(move_fn, *, uses_potential: bool = False, **kwargs):
+    key = jax.random.PRNGKey(0)
+    group1, group2 = _build_groups()
+
+    reference_key = jax.random.PRNGKey(0)
+
+    target_fn = gaussian_potential if uses_potential else gaussian_log_prob
+
+    proposed, log_accept = move_fn(group1, group2, key, target_fn, **kwargs)
+    proposed_ref, log_accept_ref = move_fn(group1, group2, reference_key, target_fn, **kwargs)
+
+    assert proposed.shape == group1.shape
+    assert log_accept.shape == (group1.shape[0],)
+
+    assert jnp.allclose(proposed, proposed_ref)
+    assert jnp.allclose(log_accept, log_accept_ref)
+
+    assert jnp.all(jnp.isfinite(proposed))
+    assert jnp.all(jnp.isfinite(log_accept))
+
+
+def _build_da_state(step_size: float = 0.25) -> DAState:
+    step_size_arr = jnp.asarray(step_size)
+    return DAState(
+        step_size=step_size_arr,
+        H_bar=jnp.asarray(0.0),
+        log_epsilon_bar=jnp.log(step_size_arr),
+    )
+
+
+def run_hamiltonian_move_test(move_fn, **kwargs):
+    key = jax.random.PRNGKey(0)
+    group1, group2 = _build_groups()
+    da_state = _build_da_state()
+
+    reference_key = jax.random.PRNGKey(0)
+
+    proposed, log_accept = move_fn(
+        group1,
+        group2,
+        da_state,
+        key,
+        gaussian_potential,
+        gaussian_potential_grad,
+        **kwargs,
+    )
+
+    proposed_ref, log_accept_ref = move_fn(
+        group1,
+        group2,
+        da_state,
+        reference_key,
+        gaussian_potential,
+        gaussian_potential_grad,
+        **kwargs,
+    )
+
+    assert proposed.shape == group1.shape
+    assert log_accept.shape == (group1.shape[0],)
+
+    assert jnp.allclose(proposed, proposed_ref)
+    assert jnp.allclose(log_accept, log_accept_ref)
+
+    assert jnp.all(jnp.isfinite(proposed))
+    assert jnp.all(jnp.isfinite(log_accept))
+
+    assert jnp.all(log_accept <= 1e-6)
+
+
+@pytest.mark.parametrize(
+    "move_fn, uses_potential",
+    [
+        (stretch_move, False),
+        (side_move, False),
+        (walk_move, True),
+    ],
+)
+def test_vanilla_moves(move_fn, uses_potential):
+    run_vanilla_move_test(move_fn, uses_potential=uses_potential)
+
+
+@pytest.mark.parametrize("move_fn", [hmc_side_move, hmc_walk_move])
+def test_hamiltonian_moves(move_fn):
+    run_hamiltonian_move_test(move_fn, L=2)

--- a/tests/test_proposal.py
+++ b/tests/test_proposal.py
@@ -1,0 +1,20 @@
+import jax
+import jax.numpy as jnp
+
+from hemcee.proposal import accept_proposal
+
+
+def test_accept_proposal_matches_expected_mask():
+    key = jax.random.PRNGKey(0)
+    current = jnp.zeros((2, 2))
+    proposed = jnp.ones((2, 2))
+    log_accept_prob = jnp.array([0.0, jnp.log(1e-8)])
+
+    updated, accepts = accept_proposal(current, proposed, log_accept_prob, key)
+
+    log_u = jnp.log(jax.random.uniform(key, shape=log_accept_prob.shape, minval=1e-10, maxval=1.0))
+    expected_accepts = (log_u < log_accept_prob).astype(int)
+    expected_updated = jnp.where(expected_accepts[:, None], proposed, current)
+
+    assert jnp.allclose(updated, expected_updated)
+    assert jnp.array_equal(accepts, expected_accepts)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,58 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+from hemcee.sampler import HamiltonianEnsembleSampler
+
+
+def gaussian_log_prob(x):
+    return -0.5 * jnp.dot(x, x)
+
+
+def test_sampler_requires_minimum_chains():
+    with pytest.raises(ValueError):
+        HamiltonianEnsembleSampler(total_chains=2, dim=2, log_prob=gaussian_log_prob)
+
+
+def test_hamiltonian_sampler_shapes_and_diagnostics():
+    total_chains = 4
+    dim = 2
+    sampler = HamiltonianEnsembleSampler(
+        total_chains=total_chains,
+        dim=dim,
+        log_prob=gaussian_log_prob,
+        step_size=0.1,
+        L=3,
+    )
+
+    key = jax.random.PRNGKey(0)
+    initial_state = jnp.zeros((total_chains, dim))
+
+    num_samples = 5
+    warmup = 3
+    thin_by = 2
+
+    samples, diagnostics = sampler.run_mcmc(
+        key,
+        initial_state,
+        num_samples=num_samples,
+        warmup=warmup,
+        thin_by=thin_by,
+        adapt_step_size=True,
+        adapt_integration=False,
+        show_progress=False,
+    )
+
+    assert samples.shape == (num_samples, total_chains, dim)
+    assert 'acceptance_rate' in diagnostics
+    assert 'step_size' in diagnostics
+    assert 'dual_averaging_state' in diagnostics
+
+    acceptance_rate = diagnostics['acceptance_rate']
+    assert 0.0 <= float(acceptance_rate) <= 1.0
+
+    step_size = diagnostics['step_size']
+    assert float(step_size) > 0.0
+
+    da_state = diagnostics['dual_averaging_state']
+    assert float(da_state.step_size) > 0.0


### PR DESCRIPTION
## Summary
- add a conftest module that exposes the project src directory to the test runner
- implement pytest coverage for the dual averaging utilities, proposal acceptance, and Hamiltonian ensemble sampler
- add reusable checks that validate vanilla and Hamiltonian move implementations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc470cc41083309769d827cf18a092